### PR TITLE
Issue #375 Update Navbar Links Styles

### DIFF
--- a/src/Assets/aurora/styles/aurora-dark-mode.css
+++ b/src/Assets/aurora/styles/aurora-dark-mode.css
@@ -268,8 +268,8 @@ html[data-color-scheme="dark"] body .auroranav.auroranav-menu-link:hover {
 }
 
 html[data-color-scheme="dark"] body .auroranav .auroranav-menu .auroranav-menu-link.current {
-    color: var(--glyph-gray) !important;
-    opacity: .5;
+    color: var(--color-figure-blue) !important;
+    opacity: 1;
 }
 
 html[data-color-scheme="dark"] body .auroranav-menustate:checked~.auroranav .auroranav-menu-link,

--- a/src/Assets/aurora/styles/aurora-nav.css
+++ b/src/Assets/aurora/styles/aurora-nav.css
@@ -867,13 +867,9 @@
 }
 
 .auroranav-menu-link.current {
-    color: #000;
-    opacity: .56;
-    cursor: default
-}
-
-.auroranav-menu-link.current:hover {
-    color: #000
+    color: var(--color-figure-blue);
+    opacity: 1;
+    cursor: default;
 }
 
 .auroranav-menustate:checked~.auroranav .auroranav-menu-link.current,


### PR DESCRIPTION
## Summary

Changed the current page link color to create more homogeneous and consistent styling across the navbar.

## Changes Made

The active state of the navbar links for Light Mode was changed from ```#000``` to ```#06c``` and for Dark Mode from ```#F5F5F7``` to ```#2997FF```. Additionally, the opacity was increased to ```1``` for both modes.

## TODO

N/A

## Motivation

The updated design is more consistent with the rest of the navbar and the link hover state, improving user experience and reducing any potential confusion caused by the previous styling.

## Testing

Tested using Dev Tools.

## Screenshots/GIFs

**Before:**

![image](https://github.com/user-attachments/assets/63d099dd-97b2-4351-bd02-29fa3677df6b)
![image](https://github.com/user-attachments/assets/07c87112-3b1f-4cdf-acae-9e6ab70f0ecd)

**After:**

![image](https://github.com/user-attachments/assets/b3bb411a-14a4-4175-86a3-fce126fc95f6)
![image](https://github.com/user-attachments/assets/9dfe5fd4-5c00-411e-a93e-b6f8fc84b1c2)

## Checklist

Please ensure all of the following are completed before submitting the PR:

- [X] Code has been tested and verified.
- [ ] Documentation has been updated to reflect the changes.
- [X] All tests pass successfully.
- [X] Code follows the project's coding guidelines and style.
- [X] The branch is up-to-date with the latest changes from the main branch.
- [ ] Reviewed by at least one other contributor.

## Related Issues

This PR addresses the following issue(s): [#375]

## Additional Notes

N/A
